### PR TITLE
use consumeClick instead of isDown in InputEvent listener

### DIFF
--- a/src/main/java/org/teacon/signin/client/Hotkey.java
+++ b/src/main/java/org/teacon/signin/client/Hotkey.java
@@ -17,7 +17,7 @@ public final class Hotkey {
 
     @SubscribeEvent
     public static void keyTyped(InputEvent.Key event) {
-        if (SignMeUpClient.keyOpenMap != null && SignMeUpClient.keyOpenMap.isDown()) {
+        if (SignMeUpClient.keyOpenMap != null && SignMeUpClient.keyOpenMap.consumeClick()) {
             Minecraft mc = Minecraft.getInstance();
             if (mc.player != null) {
                 final Vec3 position = mc.player.position();


### PR DESCRIPTION
`consumeClick`和`isDown`在InputEvent有多个listener时效果会有细微的不同：

如果`不带Modifier的键位`的监听方法调用顺序在`带Modifier的键位`的监听方法之前（`@SubscribeEvent`有相同的优先级就有可能这样），按下`带Modifier的键位`，则`不带Modifier的键位`的`isDown`会返回true，`consumeClick`为false；若顺序相反，则两个方法都是false。所以建议改成`consumeClick`来避免冲突。